### PR TITLE
Make chatops optional

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,6 +26,7 @@ variable "lambda_zip_file" {
 
 variable "lambda_chatops_zip_file" {
   description = "Zip file containing the chatops function"
+  default     = null
 }
 
 variable "lambda_function_name" {


### PR DESCRIPTION
In this PR, we no longer require ChatOps to be specified in the terraform variables when provisioning an AWS infrastructure.
After deployment, we should have only 1 lambda function.